### PR TITLE
Improve coverage target cleanup in CMake configuration

### DIFF
--- a/cmake/Coverage.cmake
+++ b/cmake/Coverage.cmake
@@ -60,6 +60,8 @@ function(AddCoverage target)
 
   add_custom_target(
     coverage-${target}
+    # Clean up the old gcda
+    COMMAND ${CMAKE_COMMAND} -E remove ${target_binary_dir}/*.gcda
     # Capture coverage data
     COMMAND ${LCOV_COMMAND} 
             --directory .


### PR DESCRIPTION
- Add step to remove old gcda files before capturing coverage data
- Ensure clean coverage data collection for target builds