### PR TITLE
Add Stream Insertion Operator for DateTime Class

### DIFF
--- a/src/framework/core/DateTime.hpp
+++ b/src/framework/core/DateTime.hpp
@@ -4,6 +4,7 @@
 #include <compare>
 #include <concepts>
 #include <format>
+#include <ostream>
 #include <stdexcept>
 #include <string>
 #include <string_view>
@@ -143,5 +144,10 @@ class DateTime {
     return *this;
   }
 };
+
+// Operator overload for stream insertion
+inline std::ostream& operator<<(std::ostream& os, const DateTime& dt) {
+  return os << dt.format();
+}
 
 }  // namespace metada::core

--- a/tests/framework/core/DateTimeTest.cpp
+++ b/tests/framework/core/DateTimeTest.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include <chrono>
+#include <sstream>
 #include <thread>
 
 #include "DateTime.hpp"
@@ -347,4 +348,21 @@ TEST(DateTimeTest, EdgeCases) {
   endOfMonth += std::chrono::days(1);
   EXPECT_EQ(endOfMonth.month(), 5);
   EXPECT_EQ(endOfMonth.day(), 1);
+}
+
+TEST(DateTimeTest, StreamInsertionOperator) {
+  DateTime dt(2023, 4, 15, 12, 30, 45);
+
+  // Test stream insertion operator (<<)
+  std::stringstream ss;
+  ss << dt;
+
+  // Should match the default format output
+  std::string expected = dt.format();
+  EXPECT_EQ(ss.str(), expected);
+
+  // Test in a more complex stream expression
+  std::stringstream ss2;
+  ss2 << "DateTime: " << dt << " is valid";
+  EXPECT_EQ(ss2.str(), "DateTime: " + expected + " is valid");
 }


### PR DESCRIPTION
- Implemented an operator overload for stream insertion (<<) in the DateTime class, allowing for easy output of DateTime objects.
- Added a corresponding unit test to verify the functionality of the stream insertion operator, ensuring it produces the expected formatted output.